### PR TITLE
Add rollup-plugin-dts as dev-dependency and use it in rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "mock-fs": "^5.2.0",
         "prettier": "3.0.3",
         "rollup": "^4.0.2",
+        "rollup-plugin-dts": "^6.1.0",
         "ts-jest": "^29.1.1",
         "tslib": "^2.6.2",
         "typescript": "^5.2.2"
@@ -5455,6 +5456,18 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+      "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -6242,6 +6255,28 @@
         "@rollup/rollup-win32-ia32-msvc": "4.1.4",
         "@rollup/rollup-win32-x64-msvc": "4.1.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz",
+      "integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.4"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.22.13"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
       }
     },
     "node_modules/run-applescript": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mock-fs": "^5.2.0",
     "prettier": "3.0.3",
     "rollup": "^4.0.2",
+    "rollup-plugin-dts": "^6.1.0",
     "ts-jest": "^29.1.1",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"
@@ -50,6 +51,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/spdx-tools.d.ts",
       "require": "./dist/spdx-tools.cjs",
       "import": "./dist/spdx-tools.mjs"
     }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,22 +1,38 @@
-import { defineConfig } from "rollup";
 import typescript from "@rollup/plugin-typescript";
+import dts from "rollup-plugin-dts";
 
-export default defineConfig({
-  input: { "spdx-tools": "lib/spdx-tools.ts" },
-  plugins: [typescript({ sourceMap: true })],
-  external: ["fs/promises", "uuid"],
-  output: [
-    {
-      dir: "dist",
-      format: "es",
-      sourcemap: true,
-      entryFileNames: "[name].mjs",
-    },
-    {
-      dir: "dist",
-      format: "cjs",
-      sourcemap: true,
-      entryFileNames: "[name].cjs",
-    },
-  ],
-});
+const config = [
+  {
+    input: { "spdx-tools": "lib/spdx-tools.ts" },
+    plugins: [typescript({ sourceMap: true })],
+    external: ["fs/promises", "uuid"],
+    output: [
+      {
+        dir: "dist",
+        format: "es",
+        sourcemap: true,
+        entryFileNames: "[name].mjs",
+      },
+      {
+        dir: "dist",
+        format: "cjs",
+        sourcemap: true,
+        entryFileNames: "[name].cjs",
+      },
+    ],
+  },
+  {
+    input: { "spdx-tools": "lib/spdx-tools.ts" },
+    plugins: [dts()],
+    output: [
+      {
+        dir: "dist",
+        format: "es",
+        sourcemap: true,
+        entryFileNames: "[name].d.ts",
+      },
+    ],
+  },
+];
+
+export default config;


### PR DESCRIPTION
The plugin rollup-plugin-dts is added in order to create .d.ts files during compilation (in addition to .cjs and .mjs files).