### PR TITLE
Avoid empty lists in created SBOM

### DIFF
--- a/examples/resources/elaborate-sample.sbom.json
+++ b/examples/resources/elaborate-sample.sbom.json
@@ -2,7 +2,7 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "comment": "This is a document for testing",
   "creationInfo": {
-    "created": "2023-10-19T10:09:21Z",
+    "created": "2023-10-19T12:16:34Z",
     "creators": [
       "Person: test creator"
     ],
@@ -28,21 +28,16 @@
       "name": "first package",
       "downloadLocation": "https://download-location.com",
       "SPDXID": "SPDXRef-first-package",
-      "filesAnalyzed": false,
-      "checksums": [],
-      "licenseInfoFromFiles": [],
-      "externalRefs": [],
-      "attributionTexts": []
+      "filesAnalyzed": true,
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "b65013ce770696a72a0dded749a5058e5f8e2a4d"
+      }
     },
     {
       "name": "second package",
       "downloadLocation": "https://download-location.com",
       "SPDXID": "SPDXRef-second-package",
-      "filesAnalyzed": false,
-      "checksums": [],
-      "licenseInfoFromFiles": [],
-      "externalRefs": [],
-      "attributionTexts": []
+      "filesAnalyzed": false
     }
   ],
   "files": [

--- a/examples/resources/minimal-sample.sbom.json
+++ b/examples/resources/minimal-sample.sbom.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T10:09:20Z",
+    "created": "2023-10-19T12:16:34Z",
     "creators": [
       "Person: test creator"
     ]
@@ -9,17 +9,13 @@
   "dataLicense": "CC0-1.0",
   "name": "first-document",
   "spdxVersion": "SPDX-2.3",
-  "documentNamespace": "https://first-document-a8ca0b43-bbab-458c-a84c-69498ed1a628",
+  "documentNamespace": "https://first-document-73d90bc7-cd35-4d46-ab5e-f1404329f4f8",
   "packages": [
     {
       "name": "first-package",
       "downloadLocation": "https://download-location.com",
       "SPDXID": "SPDXRef-first-package",
-      "filesAnalyzed": false,
-      "checksums": [],
-      "licenseInfoFromFiles": [],
-      "externalRefs": [],
-      "attributionTexts": []
+      "filesAnalyzed": false
     }
   ],
   "relationships": [

--- a/examples/resources/spdx-tools-ts.sbom.json
+++ b/examples/resources/spdx-tools-ts.sbom.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T10:09:21Z",
+    "created": "2023-10-19T12:16:34Z",
     "creators": [
       "Person: Anton Bauhofer (anton.bauhofer@tngtech.com)"
     ]
@@ -16,27 +16,27 @@
       "downloadLocation": "https://github.com/uuidjs/uuid",
       "SPDXID": "SPDXRef-uuid",
       "filesAnalyzed": true,
-      "checksums": [],
-      "licenseInfoFromFiles": [],
-      "externalRefs": [],
-      "attributionTexts": []
+      "packageVerificationCode": {
+        "packageVerificationCodeValue": "b65013ce770696a72a0dded749a5058e5f8e2a4d"
+      }
     },
     {
       "name": "eslint",
       "downloadLocation": "https://github.com/eslint/eslint",
       "SPDXID": "SPDXRef-eslint",
-      "filesAnalyzed": false,
-      "checksums": [],
-      "licenseInfoFromFiles": [],
-      "externalRefs": [],
-      "attributionTexts": []
+      "filesAnalyzed": false
     }
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-./README.md",
-      "fileName": "./README.md",
-      "checksums": [],
+      "SPDXID": "SPDXRef-README.md",
+      "fileName": "README.md",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3"
+        }
+      ],
       "fileTypes": [
         "TEXT"
       ]
@@ -60,7 +60,7 @@
     },
     {
       "spdxElementId": "SPDXRef-uuid",
-      "relatedSpdxElement": "SPDXRef-./README.me",
+      "relatedSpdxElement": "SPDXRef-README.md",
       "relationshipType": "CONTAINS"
     }
   ]

--- a/lib/converters/json/package.ts
+++ b/lib/converters/json/package.ts
@@ -8,20 +8,20 @@ export class JsonPackage {
   SPDXID: string;
   filesAnalyzed: boolean;
   packageVerificationCode?: JsonPackageVerificationCode;
-  checksums: JsonChecksum[];
-  licenseInfoFromFiles: string[];
-  externalRefs: string[];
-  attributionTexts: string[];
+  checksums?: JsonChecksum[];
+  licenseInfoFromFiles?: string[];
+  externalRefs?: string[];
+  attributionTexts?: string[];
 
   constructor(
     name: string,
     downloadLocation: string,
     SPDXID: string,
     filesAnalyzed: boolean,
-    checksums: JsonChecksum[],
-    licenseInfoFromFiles: string[],
-    externalRefs: string[],
-    attributionTexts: string[],
+    checksums?: JsonChecksum[],
+    licenseInfoFromFiles?: string[],
+    externalRefs?: string[],
+    attributionTexts?: string[],
     packageVerificationCode?: JsonPackageVerificationCode,
   ) {
     this.name = name;
@@ -36,9 +36,10 @@ export class JsonPackage {
   }
 
   static fromPackage(pkg: Package): JsonPackage {
-    const jsonChecksums: JsonChecksum[] = pkg.checksums.map((checksum) =>
-      JsonChecksum.fromChecksum(checksum),
-    );
+    const jsonChecksums: JsonChecksum[] | undefined =
+      pkg.checksums.length > 0
+        ? pkg.checksums.map((checksum) => JsonChecksum.fromChecksum(checksum))
+        : undefined;
     const jsonPackageVerificationCode: JsonPackageVerificationCode | undefined =
       pkg.verificationCode
         ? JsonPackageVerificationCode.fromPackageVerificationCode(
@@ -53,9 +54,9 @@ export class JsonPackage {
       pkg.filesAnalyzed,
       jsonChecksums,
       // TODO: Fill in licenseInfoFromFiles
-      [],
-      [],
-      [],
+      undefined,
+      undefined,
+      undefined,
       jsonPackageVerificationCode,
     );
   }


### PR DESCRIPTION
Created SBOMs should not contain empty lists. Instead, the respective properties should not be included in the document.