### PR TITLE
Rename sbom -> spdx

### DIFF
--- a/.github/workflows/verify-created-sboms.yml
+++ b/.github/workflows/verify-created-sboms.yml
@@ -31,10 +31,10 @@ jobs:
         run: .github/workflows/scripts/spdx-tools-java-wrapper.sh bootstrap
 
       - name: Verify minimal SBOM
-        run: .github/workflows/scripts/verify.sh examples/resources/minimal-sample.sbom.json
+        run: .github/workflows/scripts/verify.sh examples/resources/minimal-sample.spdx.json
 
       - name: Verify basic SBOM
-        run: .github/workflows/scripts/verify.sh examples/resources/spdx-tools-ts.sbom.json
+        run: .github/workflows/scripts/verify.sh examples/resources/spdx-tools-ts.spdx.json
 
       - name: Verify elaborate SBOM
-        run: .github/workflows/scripts/verify.sh examples/resources/elaborate-sample.sbom.json
+        run: .github/workflows/scripts/verify.sh examples/resources/elaborate-sample.spdx.json

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ document.addPackages([
     filesAnalyzed: false,
   }),
 ]);
-document.write("./sample.sbom.json");
+document.write("./sample.spdx.json");
 ```
 
 # API

--- a/examples/create-basic-sbom.ts
+++ b/examples/create-basic-sbom.ts
@@ -1,6 +1,6 @@
-import * as sbom from "../lib/spdx-tools";
+import * as spdx from "../lib/spdx-tools";
 
-const document = sbom.createDocument(
+const document = spdx.createDocument(
   "SPDX Tools ts SBOM",
   {
     name: "Anton Bauhofer",
@@ -38,4 +38,4 @@ document
   )
   .addRelationship("uuid", "README.md", "CONTAINS");
 
-document.writeSync("./examples/resources/spdx-tools-ts.sbom.json");
+document.writeSync("./examples/resources/spdx-tools-ts.spdx.json");

--- a/examples/create-elaborate-sample-sbom.ts
+++ b/examples/create-elaborate-sample-sbom.ts
@@ -1,6 +1,5 @@
 import * as sbom from "../lib/spdx-tools";
 
-const sampleSbom = "./examples/resources/elaborate-sample.sbom.json";
 const document = sbom.createDocument(
   "first-document",
   { name: "test creator", type: "Person" },
@@ -52,4 +51,4 @@ document
     },
   )
   .addRelationship("first-package", "first-file", "CONTAINS");
-document.writeSync(sampleSbom);
+document.writeSync("./examples/resources/elaborate-sample.spdx.json");

--- a/examples/create-minimal-sample-sbom.ts
+++ b/examples/create-minimal-sample-sbom.ts
@@ -1,6 +1,5 @@
 import * as sbom from "../lib/spdx-tools";
 
-const sampleSbom = "./examples/resources/minimal-sample.sbom.json";
 const document = sbom.createDocument(
   "first-document",
   { name: "test creator", type: "Person" },
@@ -9,4 +8,4 @@ const document = sbom.createDocument(
 document.addPackage("first-package", "https://download-location.com", {
   filesAnalyzed: false,
 });
-document.writeSync(sampleSbom);
+document.writeSync("./examples/resources/minimal-sample.spdx.json");

--- a/examples/resources/elaborate-sample.spdx.json
+++ b/examples/resources/elaborate-sample.spdx.json
@@ -2,7 +2,7 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "comment": "This is a document for testing",
   "creationInfo": {
-    "created": "2023-10-19T12:16:34Z",
+    "created": "2023-10-19T12:39:09Z",
     "creators": [
       "Person: test creator"
     ],

--- a/examples/resources/minimal-sample.spdx.json
+++ b/examples/resources/minimal-sample.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:16:34Z",
+    "created": "2023-10-19T12:39:09Z",
     "creators": [
       "Person: test creator"
     ]
@@ -9,7 +9,7 @@
   "dataLicense": "CC0-1.0",
   "name": "first-document",
   "spdxVersion": "SPDX-2.3",
-  "documentNamespace": "https://first-document-73d90bc7-cd35-4d46-ab5e-f1404329f4f8",
+  "documentNamespace": "https://first-document-55496a63-9774-4879-9bb3-ab65732b7cbc",
   "packages": [
     {
       "name": "first-package",

--- a/examples/resources/spdx-tools-ts.spdx.json
+++ b/examples/resources/spdx-tools-ts.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:16:34Z",
+    "created": "2023-10-19T12:39:09Z",
     "creators": [
       "Person: Anton Bauhofer (anton.bauhofer@tngtech.com)"
     ]

--- a/lib/e2e-tests/__tests__/spdx-tools.test.ts
+++ b/lib/e2e-tests/__tests__/spdx-tools.test.ts
@@ -37,9 +37,8 @@ test("Creates and writes basic document", async () => {
   const document = sbom.createDocument(
     "SPDX Tools ts SBOM",
     {
-      name: "Anton Bauhofer",
+      name: "Test User",
       type: "Person",
-      email: "anton.bauhofer@tngtech.com",
     },
     {
       namespace:
@@ -50,12 +49,12 @@ test("Creates and writes basic document", async () => {
   document
     .addPackage("uuid", "https://github.com/uuidjs/uuid", {
       verificationCode: {
-        value: "b65013ce770696a72a0dded749a5058e5f8e2a4d",
+        value: "b65013ce770696a72a0dded749a5058e5f8e2a4e",
       },
     })
     .addPackage("eslint", "https://github.com/eslint/eslint", {
       filesAnalyzed: false,
-      comment: "This package is added just for testing.",
+      comment: "This package is added for testing.",
     })
     .addRelationship("uuid", "eslint", "DEPENDS_ON");
 
@@ -63,7 +62,7 @@ test("Creates and writes basic document", async () => {
     .addFile(
       "README.md",
       {
-        checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3",
+        checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b4",
         checksumAlgorithm: "SHA1",
       },
       {
@@ -72,7 +71,7 @@ test("Creates and writes basic document", async () => {
     )
     .addRelationship("uuid", "README.md", "CONTAINS");
 
-  document.writeSync("./examples/resources/spdx-tools-ts.sbom.json");
+  document.writeSync("./examples/resources/spdx-tools-ts.spdx.json");
 
   await document.write(testfile).then(() => {
     expect(fs.lstatSync(testfile).isFile()).toBe(true);


### PR DESCRIPTION
To communicate which format is in use, 'spdx' is added to the example file names instead of 'sbom'