### PR TITLE
Fix describes relationships

### DIFF
--- a/examples/create-basic-sbom.ts
+++ b/examples/create-basic-sbom.ts
@@ -23,6 +23,7 @@ document
     filesAnalyzed: false,
     comment: "This package is added just for testing.",
   })
+  .addRelationship("DOCUMENT", "uuid", "DESCRIBES")
   .addRelationship("uuid", "eslint", "DEPENDS_ON");
 
 document

--- a/examples/create-elaborate-sample-sbom.ts
+++ b/examples/create-elaborate-sample-sbom.ts
@@ -30,6 +30,7 @@ document
       value: "b65013ce770696a72a0dded749a5058e5f8e2a4d",
     },
   })
+  .addRelationship("DOCUMENT", "first-package", "DESCRIBES")
   .addPackage("second package", "https://download-location.com", {
     filesAnalyzed: false,
     spdxId: "second-package",

--- a/examples/create-minimal-sample-sbom.ts
+++ b/examples/create-minimal-sample-sbom.ts
@@ -5,7 +5,9 @@ const document = sbom.createDocument(
   { name: "test creator", type: "Person" },
   { spdxVersion: "2.3" },
 );
-document.addPackage("first-package", "https://download-location.com", {
-  filesAnalyzed: false,
-});
+document
+  .addPackage("first-package", "https://download-location.com", {
+    filesAnalyzed: false,
+  })
+  .addRelationship("DOCUMENT", "first-package", "DESCRIBES");
 document.writeSync("./examples/resources/minimal-sample.spdx.json");

--- a/examples/resources/elaborate-sample.spdx.json
+++ b/examples/resources/elaborate-sample.spdx.json
@@ -2,7 +2,7 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "comment": "This is a document for testing",
   "creationInfo": {
-    "created": "2023-10-19T12:39:09Z",
+    "created": "2023-10-19T12:57:30Z",
     "creators": [
       "Person: test creator"
     ],
@@ -59,11 +59,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-first-package",
-      "relationshipType": "DESCRIBES"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relatedSpdxElement": "SPDXRef-second-package",
       "relationshipType": "DESCRIBES"
     },
     {

--- a/examples/resources/minimal-sample.spdx.json
+++ b/examples/resources/minimal-sample.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:39:09Z",
+    "created": "2023-10-19T12:57:30Z",
     "creators": [
       "Person: test creator"
     ]
@@ -9,7 +9,7 @@
   "dataLicense": "CC0-1.0",
   "name": "first-document",
   "spdxVersion": "SPDX-2.3",
-  "documentNamespace": "https://first-document-55496a63-9774-4879-9bb3-ab65732b7cbc",
+  "documentNamespace": "https://first-document-2ad9ca0f-15a6-4d9d-b5d6-d5f1bcf2a433",
   "packages": [
     {
       "name": "first-package",

--- a/examples/resources/spdx-tools-ts.spdx.json
+++ b/examples/resources/spdx-tools-ts.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:39:09Z",
+    "created": "2023-10-19T12:57:30Z",
     "creators": [
       "Person: Anton Bauhofer (anton.bauhofer@tngtech.com)"
     ]
@@ -46,11 +46,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relatedSpdxElement": "SPDXRef-uuid",
-      "relationshipType": "DESCRIBES"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relatedSpdxElement": "SPDXRef-eslint",
       "relationshipType": "DESCRIBES"
     },
     {

--- a/lib/api/spdx-document.ts
+++ b/lib/api/spdx-document.ts
@@ -1,6 +1,9 @@
 import { Actor } from "../spdx2model/actor";
-import type { RelationshipOptions } from "../spdx2model/relationship";
-import { Relationship, RelationshipType } from "../spdx2model/relationship";
+import type {
+  RelationshipOptions,
+  RelationshipType,
+} from "../spdx2model/relationship";
+import { Relationship } from "../spdx2model/relationship";
 import type { PackageVerificationCode } from "../spdx2model/package";
 import { Package } from "../spdx2model/package";
 import { Document } from "../spdx2model/document";
@@ -114,15 +117,9 @@ export class SPDXDocument extends Document {
     downloadLocation: string,
     options?: Partial<AddPackagesOptions>,
   ): this {
-    const pkg = new Package(name, downloadLocation, options);
-    const describesRelationship = new Relationship(
-      this.creationInfo.spdxId,
-      pkg.spdxId,
-      RelationshipType.DESCRIBES,
+    this.packages = this.packages.concat(
+      new Package(name, downloadLocation, options),
     );
-
-    this.packages = this.packages.concat(pkg);
-    this.relationships = this.relationships.concat(describesRelationship);
     return this;
   }
 


### PR DESCRIPTION
The user should control which describes relationships are added to the SBOM. So, they should not be added automatically when adding a package.