### PR TITLE
Rewrite API to enable relationships of objects with unique SPDX ids

### DIFF
--- a/.github/workflows/verify-created-sboms.yml
+++ b/.github/workflows/verify-created-sboms.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run build-examples
 
       - name: Create sample SBOM
-        run: npm run create-sample-sboms
+        run: npm run write-examples
 
       - name: Install spdx-tools-java
         run: .github/workflows/scripts/spdx-tools-java-wrapper.sh bootstrap

--- a/examples/create-basic-sbom.ts
+++ b/examples/create-basic-sbom.ts
@@ -13,30 +13,38 @@ const document = spdx.createDocument(
   },
 );
 
-document
-  .addPackage("uuid", "https://github.com/uuidjs/uuid", {
+const uuidPackage = document.addPackage(
+  "uuid",
+  "https://github.com/uuidjs/uuid",
+  {
     verificationCode: {
       value: "b65013ce770696a72a0dded749a5058e5f8e2a4d",
     },
-  })
-  .addPackage("eslint", "https://github.com/eslint/eslint", {
+  },
+);
+const eslintPackage = document.addPackage(
+  "eslint",
+  "https://github.com/eslint/eslint",
+  {
     filesAnalyzed: false,
     comment: "This package is added just for testing.",
-  })
-  .addRelationship("DOCUMENT", "uuid", "DESCRIBES")
-  .addRelationship("uuid", "eslint", "DEPENDS_ON");
+  },
+);
 
 document
-  .addFile(
-    "README.md",
-    {
-      checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3",
-      checksumAlgorithm: "SHA1",
-    },
-    {
-      fileTypes: ["TEXT"],
-    },
-  )
-  .addRelationship("uuid", "README.md", "CONTAINS");
+  .addRelationship(document, uuidPackage, "DESCRIBES")
+  .addRelationship(uuidPackage, eslintPackage, "DEPENDS_ON");
+
+const readmeFile = document.addFile(
+  "README.md",
+  {
+    checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3",
+    checksumAlgorithm: "SHA1",
+  },
+  {
+    fileTypes: ["TEXT"],
+  },
+);
+document.addRelationship(uuidPackage, readmeFile, "CONTAINS");
 
 document.writeSync("./examples/resources/spdx-tools-ts.spdx.json");

--- a/examples/create-elaborate-sample-sbom.ts
+++ b/examples/create-elaborate-sample-sbom.ts
@@ -22,34 +22,42 @@ const document = sbom.createDocument(
     documentComment: "This is a document for testing",
   },
 );
-document
-  .addPackage("first package", "https://download-location.com", {
+const firstPackage = document.addPackage(
+  "first package",
+  "https://download-location.com",
+  {
     filesAnalyzed: true,
     spdxId: "first-package",
     verificationCode: {
       value: "b65013ce770696a72a0dded749a5058e5f8e2a4d",
     },
-  })
-  .addRelationship("DOCUMENT", "first-package", "DESCRIBES")
-  .addPackage("second package", "https://download-location.com", {
+  },
+);
+
+document.addRelationship(document, firstPackage, "DESCRIBES");
+const secondPackage = document.addPackage(
+  "second package",
+  "https://download-location.com",
+  {
     filesAnalyzed: false,
     spdxId: "second-package",
-  })
-  .addRelationship("first-package", "second-package", "DEPENDENCY_OF");
+  },
+);
+document.addRelationship(firstPackage, secondPackage, "DEPENDENCY_OF");
 
-document
-  .addFile(
-    "first file",
-    [
-      {
-        checksumValue: "6a204bd89f3c8348bff90840990a7ab50fdc30ce",
-        checksumAlgorithm: "SHA1",
-      },
-    ],
+const firstFile = document.addFile(
+  "first file",
+  [
     {
-      spdxId: "first-file",
-      fileTypes: ["TEXT"],
+      checksumValue: "6a204bd89f3c8348bff90840990a7ab50fdc30ce",
+      checksumAlgorithm: "SHA1",
     },
-  )
-  .addRelationship("first-package", "first-file", "CONTAINS");
+  ],
+  {
+    spdxId: "first-file",
+    fileTypes: ["TEXT"],
+  },
+);
+
+document.addRelationship(firstPackage, firstFile, "CONTAINS");
 document.writeSync("./examples/resources/elaborate-sample.spdx.json");

--- a/examples/create-minimal-sample-sbom.ts
+++ b/examples/create-minimal-sample-sbom.ts
@@ -5,9 +5,12 @@ const document = sbom.createDocument(
   { name: "test creator", type: "Person" },
   { spdxVersion: "2.3" },
 );
-document
-  .addPackage("first-package", "https://download-location.com", {
+const pkg = document.addPackage(
+  "first-package",
+  "https://download-location.com",
+  {
     filesAnalyzed: false,
-  })
-  .addRelationship("DOCUMENT", "first-package", "DESCRIBES");
+  },
+);
+document.addRelationship(document, pkg, "DESCRIBES");
 document.writeSync("./examples/resources/minimal-sample.spdx.json");

--- a/examples/resources/elaborate-sample.spdx.json
+++ b/examples/resources/elaborate-sample.spdx.json
@@ -2,7 +2,7 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "comment": "This is a document for testing",
   "creationInfo": {
-    "created": "2023-10-19T12:57:30Z",
+    "created": "2023-10-23T08:30:57Z",
     "creators": [
       "Person: test creator"
     ],

--- a/examples/resources/minimal-sample.spdx.json
+++ b/examples/resources/minimal-sample.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:57:30Z",
+    "created": "2023-10-23T08:30:56Z",
     "creators": [
       "Person: test creator"
     ]
@@ -9,7 +9,7 @@
   "dataLicense": "CC0-1.0",
   "name": "first-document",
   "spdxVersion": "SPDX-2.3",
-  "documentNamespace": "https://first-document-2ad9ca0f-15a6-4d9d-b5d6-d5f1bcf2a433",
+  "documentNamespace": "https://first-document-2094e320-7fea-4ae3-a8a2-91d80ad38ed8",
   "packages": [
     {
       "name": "first-package",

--- a/examples/resources/spdx-tools-ts.spdx.json
+++ b/examples/resources/spdx-tools-ts.spdx.json
@@ -1,7 +1,7 @@
 {
   "SPDXID": "SPDXRef-DOCUMENT",
   "creationInfo": {
-    "created": "2023-10-19T12:57:30Z",
+    "created": "2023-10-23T08:30:57Z",
     "creators": [
       "Person: Anton Bauhofer (anton.bauhofer@tngtech.com)"
     ]

--- a/lib/e2e-tests/__tests__/spdx-tools.test.ts
+++ b/lib/e2e-tests/__tests__/spdx-tools.test.ts
@@ -46,32 +46,38 @@ test("Creates and writes basic document", async () => {
     },
   );
 
-  document
-    .addPackage("uuid", "https://github.com/uuidjs/uuid", {
+  const uuidPackage = document.addPackage(
+    "uuid",
+    "https://github.com/uuidjs/uuid",
+    {
       verificationCode: {
         value: "b65013ce770696a72a0dded749a5058e5f8e2a4e",
       },
-    })
-    .addPackage("eslint", "https://github.com/eslint/eslint", {
+    },
+  );
+  const eslintPackage = document.addPackage(
+    "eslint",
+    "https://github.com/eslint/eslint",
+    {
       filesAnalyzed: false,
       comment: "This package is added for testing.",
-    })
-    .addRelationship("uuid", "eslint", "DEPENDS_ON");
+    },
+  );
+
+  const readmeFile = document.addFile(
+    "README.md",
+    {
+      checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b4",
+      checksumAlgorithm: "SHA1",
+    },
+    {
+      fileTypes: ["TEXT"],
+    },
+  );
 
   document
-    .addFile(
-      "README.md",
-      {
-        checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b4",
-        checksumAlgorithm: "SHA1",
-      },
-      {
-        fileTypes: ["TEXT"],
-      },
-    )
-    .addRelationship("uuid", "README.md", "CONTAINS");
-
-  document.writeSync("./examples/resources/spdx-tools-ts.spdx.json");
+    .addRelationship(uuidPackage, eslintPackage, "DEPENDS_ON")
+    .addRelationship(uuidPackage, readmeFile, "CONTAINS");
 
   await document.write(testfile).then(() => {
     expect(fs.lstatSync(testfile).isFile()).toBe(true);

--- a/lib/spdx2model/document.ts
+++ b/lib/spdx2model/document.ts
@@ -111,7 +111,7 @@ export class Document {
     return validationIssues;
   }
 
-  async writeSBOM(location: string): Promise<void> {
+  async writeFile(location: string): Promise<void> {
     const convertedDocument = JsonDocument.fromDocument(this);
     const content = JSON.stringify(convertedDocument, null, 2);
     await fs.writeFile(location, content);

--- a/lib/spdx2model/file.ts
+++ b/lib/spdx2model/file.ts
@@ -1,4 +1,5 @@
 import type { Checksum } from "./checksum";
+import { v4 as uuidv4 } from "uuid";
 
 export enum FileType {
   OTHER = "OTHER",
@@ -32,7 +33,7 @@ export class File {
     options?: Partial<FileOptions>,
   ) {
     this.name = name;
-    this.spdxId = "SPDXRef-" + (options?.spdxId ?? name);
+    this.spdxId = "SPDXRef-" + uuidv4();
     this.checksums = checksums;
     this.fileTypes = options?.fileTypes ?? undefined;
   }

--- a/lib/spdx2model/package.ts
+++ b/lib/spdx2model/package.ts
@@ -1,6 +1,7 @@
 import type { Actor } from "./actor";
 import type { Checksum } from "./checksum";
 import type { spdxNoAssertion, spdxNone } from "./spdx-types";
+import { v4 as uuidv4 } from "uuid";
 
 interface PackageOptions {
   spdxId: string;
@@ -86,7 +87,7 @@ export class Package {
   ) {
     this.name = name;
     this.downloadLocation = downloadLocation;
-    this.spdxId = "SPDXRef-" + (options?.spdxId ?? name);
+    this.spdxId = "SPDXRef-" + uuidv4();
     this.version = options?.version ?? undefined;
     this.fileName = options?.fileName ?? undefined;
     this.supplier = options?.supplier ?? undefined;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin typescript",
     "build-examples": "rollup --config examples/rollup.config.ts --configPlugin typescript",
-    "create-sample-sboms": "node examples/build/create-minimal-sample-sbom.js && node examples/build/create-elaborate-sample-sbom.js && node examples/build/create-basic-sbom.js",
+    "write-examples": "node examples/build/create-minimal-sample-sbom.js && node examples/build/create-elaborate-sample-sbom.js && node examples/build/create-basic-sbom.js",
     "lint-check": "eslint -c .eslintrc.js --ext .ts,.js .",
     "lint-fix": "eslint -c .eslintrc.js --fix --ext .ts,.js .",
     "prepare": "husky install && npm run build",


### PR DESCRIPTION
To enable relationships of objects with unique ids, without the need of the user providing the ids as arguments, the instances need to be returned and provided as arguments for the relationships.