### PR TITLE
Minor improvements for domain classes

### DIFF
--- a/lib/api/spdx-document.ts
+++ b/lib/api/spdx-document.ts
@@ -35,6 +35,7 @@ export interface InputChecksum {
 
 export interface CreateDocumentOptions {
   spdxVersion: string;
+  spdxId: string;
   created: Date;
   namespace: string;
   externalDocumentRefs: DocumentRef[];
@@ -59,8 +60,10 @@ export interface AddFileOptions {
 export class SPDXDocument extends Document {
   private static formatCreators(creators: Creator | Creator[]): Actor[] {
     return Array.isArray(creators)
-      ? creators.map((creator) => Actor.fromCreator(creator))
-      : [Actor.fromCreator(creators)];
+      ? creators
+          .map((creator) => Actor.fromCreator(creator))
+          .concat(Actor.tools())
+      : [Actor.fromCreator(creators)].concat(Actor.tools());
   }
 
   private static formatSpdxVersion(spdxVersion?: string): string {

--- a/lib/spdx2model/actor.ts
+++ b/lib/spdx2model/actor.ts
@@ -25,6 +25,10 @@ export class Actor {
     return new Actor(creator.name, actorType, creator.email);
   }
 
+  static tools(): Actor {
+    return new Actor("SPDX Tools TS", ActorType.Tool);
+  }
+
   toString(): string {
     return (
       this.type.valueOf() +

--- a/lib/spdx2model/document-creation-info.ts
+++ b/lib/spdx2model/document-creation-info.ts
@@ -2,6 +2,7 @@ import type { Actor } from "./actor";
 import type { ExternalDocumentRef } from "./external-document-ref";
 
 export interface DocumentCreationInfoOptions {
+  spdxId: string;
   created: Date;
   dataLicense: string;
   externalDocumentRefs: ExternalDocumentRef[];
@@ -14,7 +15,7 @@ export class DocumentCreationInfo {
   spdxVersion: string;
   dataLicense: string = "CC0-1.0";
   // TODO: Verify that this is correct
-  spdxId: string = "SPDXRef-DOCUMENT";
+  spdxId: string;
   name: string;
   documentNamespace: string;
   externalDocumentRefs: ExternalDocumentRef[];
@@ -41,5 +42,6 @@ export class DocumentCreationInfo {
     this.creatorComment = options?.creatorComment ?? undefined;
     this.licenseListVersion = options?.licenseListVersion ?? undefined;
     this.documentComment = options?.documentComment ?? undefined;
+    this.spdxId = options?.spdxId ?? "SPDXRef-DOCUMENT";
   }
 }

--- a/lib/spdx2model/document.ts
+++ b/lib/spdx2model/document.ts
@@ -51,11 +51,10 @@ export class Document {
       (relationship) => relationship.relationshipType === "DESCRIBED_BY",
     );
 
-    return (
-      !hasOnlyOnePackage &&
-      !(
-        describesRelationships.length > 0 || describedByRelationships.length > 0
-      )
+    return !(
+      hasOnlyOnePackage ||
+      describesRelationships.length > 0 ||
+      describedByRelationships.length > 0
     );
   }
 

--- a/lib/spdx2model/file.ts
+++ b/lib/spdx2model/file.ts
@@ -25,7 +25,7 @@ export class File {
   name: string;
   spdxId: string;
   checksums: Checksum[];
-  fileTypes?: FileType[];
+  fileTypes: FileType[];
 
   constructor(
     name: string,
@@ -35,6 +35,6 @@ export class File {
     this.name = name;
     this.spdxId = "SPDXRef-" + uuidv4();
     this.checksums = checksums;
-    this.fileTypes = options?.fileTypes ?? undefined;
+    this.fileTypes = options?.fileTypes ?? [];
   }
 }


### PR DESCRIPTION
- The norm we use currently is to have empty lists for the domain objects (those save us a couple of unnecessary handlings) and undefined for the optional properties in the json objects (in order not to have empty lists in the written files).
- Add this SPDX Tool itself to the document creators
- Allow setting document SPDX ID

fixes https://github.com/spdx/tools-ts/issues/76
fixes https://github.com/spdx/tools-ts/issues/77
fixes https://github.com/spdx/tools-ts/issues/78