### PR TITLE
Make creators optional

### DIFF
--- a/examples/create-basic-sbom.ts
+++ b/examples/create-basic-sbom.ts
@@ -1,17 +1,14 @@
 import * as spdx from "../lib/spdx-tools";
 
-const document = spdx.createDocument(
-  "SPDX Tools ts SBOM",
-  {
+const document = spdx.createDocument("SPDX Tools ts SBOM", {
+  namespace:
+    "https://github.com/spdx/tools-ts/examples/resources/spdx-tools-ts.sbom.json-21b3f009-ac30-4da3-a295-7172e0c4ba49",
+  creators: {
     name: "Anton Bauhofer",
     type: "Person",
     email: "anton.bauhofer@tngtech.com",
   },
-  {
-    namespace:
-      "https://github.com/spdx/tools-ts/examples/resources/spdx-tools-ts.sbom.json-21b3f009-ac30-4da3-a295-7172e0c4ba49",
-  },
-);
+});
 
 const uuidPackage = document.addPackage(
   "uuid",

--- a/examples/create-elaborate-sample-sbom.ts
+++ b/examples/create-elaborate-sample-sbom.ts
@@ -1,27 +1,24 @@
 import * as sbom from "../lib/spdx-tools";
 
-const document = sbom.createDocument(
-  "first-document",
-  { name: "test creator", type: "Person" },
-  {
-    spdxVersion: "2.3",
-    created: new Date(),
-    namespace:
-      "https://my-website.com/paths-to-spdx-document/my-document-21b3f009-ac30-4da3-a295-7172e0c4ba49",
-    externalDocumentRefs: [
-      {
-        documentRefId: "DocumentRef-referenced-document-id",
-        documentUri:
-          "https://referenced-document.com/paths-to/document-4fced07f-b166-4203-a409-4275b7c5e642",
-        checksum_value: "5d41402abc4b2a76b9719d911017c592cb8d5e0e",
-        checksum_algorithm: "SHA1",
-      },
-    ],
-    creatorComment: "This document was created automatically",
-    licenseListVersion: "3.14",
-    documentComment: "This is a document for testing",
-  },
-);
+const document = sbom.createDocument("first-document", {
+  spdxVersion: "2.3",
+  created: new Date(),
+  creators: { name: "test creator", type: "Person" },
+  namespace:
+    "https://my-website.com/paths-to-spdx-document/my-document-21b3f009-ac30-4da3-a295-7172e0c4ba49",
+  externalDocumentRefs: [
+    {
+      documentRefId: "DocumentRef-referenced-document-id",
+      documentUri:
+        "https://referenced-document.com/paths-to/document-4fced07f-b166-4203-a409-4275b7c5e642",
+      checksum_value: "5d41402abc4b2a76b9719d911017c592cb8d5e0e",
+      checksum_algorithm: "SHA1",
+    },
+  ],
+  creatorComment: "This document was created automatically",
+  licenseListVersion: "3.14",
+  documentComment: "This is a document for testing",
+});
 const firstPackage = document.addPackage(
   "first package",
   "https://download-location.com",

--- a/examples/create-minimal-sample-sbom.ts
+++ b/examples/create-minimal-sample-sbom.ts
@@ -1,10 +1,6 @@
 import * as sbom from "../lib/spdx-tools";
 
-const document = sbom.createDocument(
-  "first-document",
-  { name: "test creator", type: "Person" },
-  { spdxVersion: "2.3" },
-);
+const document = sbom.createDocument("first-document", { spdxVersion: "2.3" });
 const pkg = document.addPackage(
   "first-package",
   "https://download-location.com",

--- a/lib/api/__tests__/spdx-document.test.ts
+++ b/lib/api/__tests__/spdx-document.test.ts
@@ -2,10 +2,7 @@ import { SPDXDocument } from "../spdx-document";
 
 test("generates valid namespace from document name", () => {
   const documentName = "-!+My:first test-Name";
-  const document = SPDXDocument.createDocument(documentName, {
-    name: "test creator",
-    type: "Person",
-  });
+  const document = SPDXDocument.createDocument(documentName);
   expect(document.creationInfo.documentNamespace.substring(0, 23)).toBe(
     "urn:My-first-test-Name",
   );

--- a/lib/e2e-tests/__tests__/spdx-tools.test.ts
+++ b/lib/e2e-tests/__tests__/spdx-tools.test.ts
@@ -10,11 +10,7 @@ test("Creates and writes minimal document", async () => {
   mock({ "root/dir": { "existingFile.txt": "" } });
   const testfile = "root/dir/sbom.spdx.json";
 
-  const document = sbom.createDocument(
-    "test document",
-    { name: "test creator", type: "Person" },
-    { spdxVersion: "2.3" },
-  );
+  const document = sbom.createDocument("test document", { spdxVersion: "2.3" });
   document.addPackage("test-package", "test/download/location", {
     spdxId: "package-spdx-id",
   });
@@ -24,9 +20,6 @@ test("Creates and writes minimal document", async () => {
     const parsedFileContent = JSON.parse(writtenFileContent);
     expect(parsedFileContent.packages[0].name).toBe("test-package");
     expect(parsedFileContent.name).toBe("test document");
-    expect(parsedFileContent.creationInfo.creators).toStrictEqual([
-      "Person: test creator",
-    ]);
   });
 });
 
@@ -34,17 +27,10 @@ test("Creates and writes basic document", async () => {
   mock({ "root/dir": { "existingFile.txt": "" } });
   const testfile = "root/dir/sbom.spdx.json";
 
-  const document = sbom.createDocument(
-    "SPDX Tools ts SBOM",
-    {
-      name: "Test User",
-      type: "Person",
-    },
-    {
-      namespace:
-        "https://github.com/spdx/tools-ts/examples/resources/spdx-tools-ts.sbom.json-21b3f009-ac30-4da3-a295-7172e0c4ba49",
-    },
-  );
+  const document = sbom.createDocument("SPDX Tools ts SBOM", {
+    namespace:
+      "https://github.com/spdx/tools-ts/examples/resources/spdx-tools-ts.sbom.json-21b3f009-ac30-4da3-a295-7172e0c4ba49",
+  });
 
   const uuidPackage = document.addPackage(
     "uuid",

--- a/lib/spdx-tools.ts
+++ b/lib/spdx-tools.ts
@@ -1,20 +1,17 @@
-import type { CreateDocumentOptions, Creator } from "./api/spdx-document";
+import type { CreateDocumentOptions } from "./api/spdx-document";
 import { SPDXDocument as SPDX2Document } from "./api/spdx-document";
 
 function parseMajorVersion(spdxVersion: string): number {
   return parseInt(spdxVersion.split(".")[0]);
 }
 
-export type { Creator } from "./api/spdx-document";
-
 export function createDocument(
   name: string,
-  creators: Creator | Creator[],
   options?: Partial<CreateDocumentOptions>,
 ): SPDX2Document {
   const spdxVersion = options?.spdxVersion;
   if (!spdxVersion || parseMajorVersion(spdxVersion) === 2) {
-    return SPDX2Document.createDocument(name, creators, options);
+    return SPDX2Document.createDocument(name, options);
   } else {
     throw new Error("Unsupported SPDX version");
   }


### PR DESCRIPTION
In https://github.com/spdx/tools-ts/pull/81, we added "SPDX Tools TS" as an actor to the document creators. With that implemented, creators could now be an optional argument.

fixes https://github.com/spdx/tools-ts/issues/82