### PR TITLE
Fix commands in readme

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -40,11 +40,9 @@ Packages are used to describe the contents of a software package.
 After creating a document (see [Documents](#Documents)), packages can be added with the command `document.addPackages`:
 
 ```javascript
-const pkg = document.addPackages([
-    new Package("my-package", {
-        downloadLocation: "https://download-location.com",
-    }),
-]);
+const pkg = document.addPackage("my-package", {
+    downloadLocation: "https://download-location.com",
+});
 ```
 
 It requires the following arguments:
@@ -69,15 +67,17 @@ Files are used to provide information about files that are contained in software
 After creating a document (see [Documents](#Documents)), files can be added with the command `document.addFiles`:
 
 ```javascript
-document.addFiles([
-    new File("my-file", {
+document.addFile(
+    "my-file",
+    {
         checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3",
         checksumAlgorithm: "SHA1",
-    }, {
+    },
+    {
         fileTypes: ["TEXT"],
         concludedLicense: "MIT",
-    }),
-]);
+    },
+);
 ```
 
 It requires the following arguments:

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ The recommended way to use this library is to create a document, add contents to
 import sbom from "../spdx-tools";
 import { Package } from "../spdx2model/package";
 
-const document = sbom.createDocument(
-  "my-first-document",
-  { name: "me", type: "Person" },
-  { spdxVersion: "2.3" },
-);
-document.addPackages([
-  new Package("first-package", "https://download-location.com", {
-    filesAnalyzed: false,
-  }),
-]);
+const document = sbom.createDocument("my-first-document");
+const pkg = document.addPackage("my-package");
+document.addRelationship(document, pkg, "DESCRIBES");
+
 document.write("./sample.spdx.json");
 ```
 

--- a/examples/resources/elaborate-sample.spdx.json
+++ b/examples/resources/elaborate-sample.spdx.json
@@ -2,7 +2,7 @@
   "SPDXID": "SPDXRef-DOCUMENT",
   "comment": "This is a document for testing",
   "creationInfo": {
-    "created": "2023-10-31T12:19:33Z",
+    "created": "2023-10-31T13:00:09Z",
     "creators": [
       "Person: test creator",
       "Tool: SPDX Tools TS"
@@ -43,7 +43,7 @@
   ],
   "files": [
     {
-      "SPDXID": "SPDXRef-66f4a187-92cc-4657-8923-386e7a3e0f6d",
+      "SPDXID": "SPDXRef-02c9dd6a-e3ec-4119-9dc5-c4a26c79d2df",
       "fileName": "first file",
       "checksums": [
         {
@@ -69,7 +69,7 @@
     },
     {
       "spdxElementId": "SPDXRef-first-package",
-      "relatedSpdxElement": "SPDXRef-66f4a187-92cc-4657-8923-386e7a3e0f6d",
+      "relatedSpdxElement": "SPDXRef-02c9dd6a-e3ec-4119-9dc5-c4a26c79d2df",
       "relationshipType": "CONTAINS"
     }
   ]


### PR DESCRIPTION
 Before this fix, the example commands were outdated.