### PR TITLE
Introduce converter function to handle SPDX types.

### DIFF
--- a/lib/spdx2model/spdx-types.ts
+++ b/lib/spdx2model/spdx-types.ts
@@ -1,11 +1,40 @@
+const NOASSERTION = "NOASSERTION";
+const NONE = "NONE";
+
 export class SpdxNoAssertion {
   toString(): string {
-    return "NOASSERTION";
+    return NOASSERTION;
   }
 }
 
 export class SpdxNone {
   toString(): string {
-    return "NONE";
+    return NONE;
+  }
+}
+
+export type ConverterFunction<T> = (entry: string) => T;
+
+export function toSpdxType<T = string>(
+  entry: string,
+  converter?: ConverterFunction<T>,
+): T | string | SpdxNoAssertion | SpdxNone {
+  const defaultConverter = (entry: string): string => {
+    return entry;
+  };
+  if (entry === NOASSERTION) {
+    return new SpdxNoAssertion();
+  } else if (entry === NONE) {
+    return new SpdxNone();
+  } else {
+    return converter ? converter(entry) : defaultConverter(entry);
+  }
+}
+
+export function validateSpdxNoAssertion(
+  value: string | SpdxNoAssertion | SpdxNone,
+): void {
+  if (!(value instanceof SpdxNoAssertion || typeof value === "string")) {
+    throw new Error(`Invalid entry: ${value.toString()} is not allowed.`);
   }
 }


### PR DESCRIPTION
Some fields in the SPDX model allow for "NOASSERTION" and / or "NONE" values. We use classes for these in the model, but don't want to expose those classes in the API. So, here, we introduce a converter to handle the input values.