### PR TITLE
Rollup plugin

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,5 @@ node_modules/
 dist/
 examples/build/
 yarn-plugin/bundles/
+rollup-plugin/__tests__/dist
+

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 yarn-plugin/
+rollup-plugin/

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ node_modules/
 dist/
 examples/build/
 yarn-plugin/bundles/
+rollup-plugin/__tests__/dist

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -6,3 +6,11 @@ Source: https://github.com/spdx/tools-ts
 Files: dist/*
 Copyright: 2023 SPDX contributors
 License: MIT
+
+Files: yarn-plugin/bundles/*
+Copyright: 2023 SPDX contributors
+License: MIT
+
+Files: rollup-plugin/examples/dist/*
+Copyright: 2023 SPDX contributors
+License: MIT

--- a/rollup-plugin/examples/dist/hello.spdx.json
+++ b/rollup-plugin/examples/dist/hello.spdx.json
@@ -1,0 +1,77 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "creationInfo": {
+    "created": "2023-11-24T15:24:50Z",
+    "creators": [
+      "Tool: SPDX Tools TS"
+    ]
+  },
+  "dataLicense": "CC0-1.0",
+  "name": "hello",
+  "spdxVersion": "SPDX-2.3",
+  "documentNamespace": "urn:hello:4385d36a-2050-44b0-a22b-234aaf6e954e",
+  "files": [
+    {
+      "SPDXID": "SPDXRef-rollup-plugin-examples-index.ts",
+      "fileName": "rollup-plugin/examples/index.ts",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "9429c596f28aae32110399c1683596c7bd19d351"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-rollup-plugin-examples-hello-world.ts",
+      "fileName": "rollup-plugin/examples/hello-world.ts",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "06950759f6a8369e4d019a3a1861770407d7b794"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-rollup-plugin-examples-hello-mars.ts",
+      "fileName": "rollup-plugin/examples/hello-mars.ts",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "15822071414e575cedf5b5826129242e42493cd3"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-rollup-plugin-examples-dist-index.js",
+      "fileName": "rollup-plugin/examples/dist/index.js",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "ebf479a71fdefb613246f4cc120dd489d8c88101"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-rollup-plugin-examples-index.ts",
+      "relatedSpdxElement": "SPDXRef-rollup-plugin-examples-hello-world.ts",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-rollup-plugin-examples-index.ts",
+      "relatedSpdxElement": "SPDXRef-rollup-plugin-examples-hello-mars.ts",
+      "relationshipType": "DEPENDS_ON"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relatedSpdxElement": "SPDXRef-rollup-plugin-examples-dist-index.js",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-rollup-plugin-examples-dist-index.js",
+      "relatedSpdxElement": "SPDXRef-rollup-plugin-examples-index.ts",
+      "relationshipType": "GENERATED_FROM"
+    }
+  ]
+}

--- a/rollup-plugin/examples/dist/index.js
+++ b/rollup-plugin/examples/dist/index.js
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+function helloWorld() {
+    console.log("hello world");
+}
+
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+function helloMars() {
+    console.log("hello mars");
+}
+
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+helloWorld();
+helloMars();

--- a/rollup-plugin/examples/hello-mars.ts
+++ b/rollup-plugin/examples/hello-mars.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+
+export function helloMars(): void {
+  console.log("hello mars");
+}

--- a/rollup-plugin/examples/hello-world.ts
+++ b/rollup-plugin/examples/hello-world.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+
+export function helloWorld(): void {
+  console.log("hello world");
+}

--- a/rollup-plugin/examples/index.ts
+++ b/rollup-plugin/examples/index.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+
+import { helloWorld } from "./hello-world";
+import { helloMars } from "./hello-mars";
+
+helloWorld();
+helloMars();

--- a/rollup-plugin/examples/rollup.config.ts
+++ b/rollup-plugin/examples/rollup.config.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+
+import { defineConfig } from "rollup";
+import spdxPlugin from "../spdx-plugin";
+import typescript from "@rollup/plugin-typescript";
+import { fileURLToPath } from "url";
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  input: `${__dirname}index.ts`,
+  plugins: [spdxPlugin("hello"), typescript({})],
+  output: { dir: `${__dirname}dist`, format: "es" },
+});

--- a/rollup-plugin/package-lock.json
+++ b/rollup-plugin/package-lock.json
@@ -1,0 +1,234 @@
+{
+  "name": "rollup-plugin-spdx",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rollup-plugin-spdx",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "sha1-file": "^3.0.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-typescript": "^11.1.5",
+        "@types/node": "^20.8.4",
+        "typescript": "^5.2.2"
+      }
+    },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.5.tgz",
+      "integrity": "sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0||^4.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasha": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+      "dependencies": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sha1-file": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sha1-file/-/sha1-file-3.0.0.tgz",
+      "integrity": "sha512-RnEaJUybyMkBRBB1zExj2xEUUxqgu8u2fwVdzzSq7IdL9uBOtbdZY6/K1WtP1QYtOhzUlD7yRgDRdvB/H4Ie9Q==",
+      "dependencies": {
+        "hasha": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    }
+  }
+}

--- a/rollup-plugin/package-lock.json.license
+++ b/rollup-plugin/package-lock.json.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: MIT

--- a/rollup-plugin/package.json
+++ b/rollup-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "rollup-plugin-spdx",
+  "version": "0.0.1",
+  "description": "A Rollup plugin to create SPDX SBOM files",
+  "license": "MIT",
+  "main": "spdx-plugin.ts",
+  "scripts": {
+    "test": "cd .. && rollup -c rollup-plugin/examples/rollup.config.ts --configPlugin typescript"
+  },
+  "dependencies": {
+    "sha1-file": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.4",
+    "@rollup/plugin-typescript": "^11.1.5",
+    "typescript": "^5.2.2"
+  }
+}

--- a/rollup-plugin/package.json.license
+++ b/rollup-plugin/package.json.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: MIT

--- a/rollup-plugin/spdx-plugin.ts
+++ b/rollup-plugin/spdx-plugin.ts
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: 2023 spdx contributors
+//
+// SPDX-License-Identifier: MIT
+
+import * as spdx from "../lib/spdx-tools";
+import * as path from "path";
+import { sha1File } from "sha1-file";
+import type { SPDXDocument as SPDX2Document } from "../lib/api/spdx-document";
+
+const SPDX_ID_PREPENDIX = "SPDXRef-";
+const SPDX_DESCRIBES = "DESCRIBES";
+const SPDX_DEPENDS_ON = "DEPENDS_ON";
+const SPDX_GENERATED_FROM = "GENERATED_FROM";
+const SHA1 = "SHA1";
+
+interface relationship {
+  element: string;
+  relatedElement: string;
+  relationshipType: string;
+}
+
+export default function spdxPlugin(outputName: string): any {
+  const spdxDocument = spdx.createDocument(outputName);
+  const collectedInputFiles = new Set<string>();
+  const collectedRelationships = new Set<relationship>();
+
+  return {
+    name: "spdx-plugin",
+
+    moduleParsed(moduleInfo: any): void {
+      const fileLocation = getRelativeLocation(moduleInfo.id);
+      const dependencyLocations = moduleInfo.importedIds.map((id: string) => {
+        return getRelativeLocation(id);
+      });
+
+      dependencyLocations.forEach((dependencyLocation: string) => {
+        const relationship: relationship = {
+          element: spdxIdFromLocation(fileLocation),
+          relatedElement: spdxIdFromLocation(dependencyLocation),
+          relationshipType: SPDX_DEPENDS_ON,
+        };
+        if (!collectedRelationships.has(relationship)) {
+          collectedRelationships.add(relationship);
+        }
+      });
+
+      if (collectedInputFiles.has(fileLocation)) {
+        return;
+      }
+      collectedInputFiles.add(fileLocation);
+
+      addFileFromModuleToDocument(fileLocation, spdxDocument)
+        .then(() => {})
+        .catch((error) => {
+          throw error;
+        });
+    },
+
+    writeBundle(options: any, bundle: any): void {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const outputDirectory = options.dir!;
+
+      collectDescribesRelationships(
+        bundle,
+        spdxDocument,
+        collectedRelationships,
+        outputDirectory,
+      );
+      collectGeneratedFromRelationships(
+        bundle,
+        collectedInputFiles,
+        collectedRelationships,
+        outputDirectory,
+      );
+
+      addRelationshipsToDocument(spdxDocument, collectedRelationships);
+
+      addFilesFromBundleToDocument(bundle, spdxDocument, outputDirectory)
+        .then(() => {
+          if (options.file) {
+            throw new Error("options.file is not supported");
+          }
+          const spdxDocumentLocation = path.resolve(
+            outputDirectory,
+            `${outputName}.spdx.json`,
+          );
+          spdxDocument.writeSync(spdxDocumentLocation, true);
+        })
+        .catch((error) => {
+          throw error;
+        });
+    },
+  };
+}
+
+function getRelativeLocation(absoluteLocation: string): string {
+  return path.relative(process.cwd(), absoluteLocation);
+}
+
+async function addFileFromModuleToDocument(
+  id: any,
+  spdxDocument: SPDX2Document,
+): Promise<void> {
+  sha1File(path.resolve(id)).then((hash) => {
+    spdxDocument.addFile(
+      id,
+      {
+        checksumAlgorithm: SHA1,
+        checksumValue: hash,
+      },
+      {
+        spdxId: spdxIdFromLocation(id),
+      },
+    );
+  });
+}
+
+function collectDescribesRelationships(
+  bundle: any,
+  spdxDocument: SPDX2Document,
+  collectedRelationships: Set<relationship>,
+  outputDirectory: string,
+): void {
+  for (const key in bundle) {
+    const fileLocation = getRelativeLocation(
+      `${outputDirectory}/${bundle[key].fileName}`,
+    );
+    const relationship: relationship = {
+      element: spdxDocument.creationInfo.spdxId,
+      relatedElement: spdxIdFromLocation(fileLocation),
+      relationshipType: SPDX_DESCRIBES,
+    };
+    if (!collectedRelationships.has(relationship)) {
+      collectedRelationships.add(relationship);
+    }
+  }
+}
+
+function collectGeneratedFromRelationships(
+  bundle: any,
+  collectedInputFiles: Set<string>,
+  collectedRelationships: Set<relationship>,
+  outputDirectory: string,
+): void {
+  for (const key in bundle) {
+    const fileLocation = getRelativeLocation(
+      `${outputDirectory}/${bundle[key].fileName}`,
+    );
+
+    if (!bundle[key].facadeModuleId) {
+      continue;
+    }
+    const referenceFileLocation = getRelativeLocation(
+      bundle[key].facadeModuleId,
+    );
+    if (!collectedInputFiles.has(referenceFileLocation)) {
+      continue;
+    }
+
+    const relationship: relationship = {
+      element: spdxIdFromLocation(fileLocation),
+      relatedElement: spdxIdFromLocation(referenceFileLocation),
+      relationshipType: SPDX_GENERATED_FROM,
+    };
+    if (!collectedRelationships.has(relationship)) {
+      collectedRelationships.add(relationship);
+    }
+  }
+}
+
+function addRelationshipsToDocument(
+  spdxDocument: SPDX2Document,
+  collectedRelationships: Set<relationship>,
+): void {
+  collectedRelationships.forEach((relationship) => {
+    spdxDocument.addRelationship(
+      relationship.element,
+      relationship.relatedElement,
+      relationship.relationshipType,
+    );
+  });
+}
+
+async function addFilesFromBundleToDocument(
+  bundle: any,
+  spdxDocument: SPDX2Document,
+  outputDirectory: string,
+): Promise<void> {
+  const promises = [];
+  for (const key in bundle) {
+    const fileLocation = getRelativeLocation(
+      `${outputDirectory}/${bundle[key].fileName}`,
+    );
+    promises.push(
+      sha1File(path.resolve(fileLocation)).then((hash) => {
+        spdxDocument.addFile(
+          fileLocation,
+          {
+            checksumAlgorithm: SHA1,
+            checksumValue: hash,
+          },
+          {
+            spdxId: spdxIdFromLocation(fileLocation),
+          },
+        );
+      }),
+    );
+  }
+  await Promise.all(promises);
+}
+
+function spdxIdFromLocation(filePath: string): string {
+  return SPDX_ID_PREPENDIX + filePath.replace(/[^a-zA-Z0-9.-]+/g, "-");
+}

--- a/rollup-plugin/tsconfig.json
+++ b/rollup-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["esnext"]
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/rollup-plugin/tsconfig.json.license
+++ b/rollup-plugin/tsconfig.json.license
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 spdx contributors
+#
+# SPDX-License-Identifier: MIT

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   },
   "include": [
     "lib/**/*",
+    "rollup-plugin/**/*",
     "examples/**/*",
     ".eslintrc.js",
     "jest.config.js",

--- a/yarn-plugin/bundles/@yarnpkg/plugin-spdx.js.license
+++ b/yarn-plugin/bundles/@yarnpkg/plugin-spdx.js.license
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2023 SPDX contributors
-#
-# SPDX-License-Identifier: MIT


### PR DESCRIPTION
This implements an MVP for a Rollup plugin that can be used to create an SPDX SBOM which lists the files contained in a Rollup plugin and their dependencies.

Graph of the example SPDX document:
![hello-graph](https://github.com/spdx/tools-ts/assets/48415604/aef47e01-0e11-4dc2-8db5-17b648ba5489)

Fixes https://github.com/spdx/tools-ts/issues/122