### PR TITLE
Add separate readme aimed at users who download the library from the npm registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implementation of [SPDX 2.3 model] (https://spdx.github.io/spdx-spec/v2.3/) with documents, packages, files and relationships.
 - API for creating, filling, and writing SPDX documents.
 - JSON serialization according to the [SPDX 2.3 schema] (https://github.com/spdx/spdx-spec/blob/development/v2.3.1/schemas/spdx-schema.json).
+
+## [0.0.2] - 2023-11-27
+### Added
+- Separate readme aimed at users of the library.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ SPDX-License-Identifier: CC0-1.0
 We provide a number of example workflows in the `examples` directory that demonstrate how this library can be used to create SBOMs.
 
 ## Usage
-`SPDXSBOM` provides an API to compose and write SBOMs in the SPDX format.
+The library provides an API to compose and write SBOMs in the SPDX format.
 The recommended way to use this library is to create a document, add contents to it and then write it to a file:
 
 ```javascript
-import sbom from "../spdx-tools";
-import { Package } from "../spdx2model/package";
+import * as spdx from "../lib/spdx-tools";
 
 const document = sbom.createDocument("my-first-document");
 const pkg = document.addPackage("my-package");

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,228 @@
+<!--
+SPDX-FileCopyrightText: 2023 SPDX contributors
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# @spdx/tools
+Compose and write SBOMs in the SPDX format.
+
+**Important:** This repository is in early development state and can not yet be used in production.
+
+## Usage
+The recommended way to use this library is to create a document, add contents to it and then write it to a file:
+
+```javascript
+import * as spdx from "@spdx/tools";
+
+const document = sbom.createDocument("my-first-document");
+const pkg = document.addPackage("my-package");
+document.addRelationship(document, pkg, "DESCRIBES");
+
+document.write("./sample.spdx.json");
+```
+
+## Supported features
+This library is currently in early development state and not all features of SPDX are supported yet.
+The following features are supported by this library:
+
+### SPDX 2.3:
+| Feature | State |
+| ------- | ----- |
+| Document creation | DONE
+| Packages | DONE
+| Files | DONE
+| Relationships | DONE
+| Snippets | PLANNED
+| Annotations | PLANNED
+| Other licensing information | PLANNED
+
+## API
+
+For further documentation on the SPDX format, please refer to the [official SPDX specification](https://spdx.github.io/spdx-spec/v2.3/).
+
+### Documents
+Documents form the basis of SPDX SBOMs.
+They contain all information and can be exported to different formats (currently only json is supported).
+Documents can be created with the command `sbom.createDocument`:
+
+```javascript
+const document = sbom.createDocument(
+    "my-first-document",
+    [{ name: "My Name", type: "Person" }],
+);
+```
+
+It requires the following arguments:
+
+| Argument | Format | Description |
+| ----------- | ----------- | ----------- |
+| name | String | Name of the document |
+| Creators | [{name: string, type: "Person" / "Organization" / "Tool", email?: string}] | Creators of the document |
+
+In addition, it takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| spdxVersion | string | 2.3 | SPDX version of the document |
+| created | Date | current moment | Date of creation of the document |
+| namespace | string | "https://\<documentName\>-\<UUID\>" | Namespace of the document |
+| dataLicense | string | "CC0-1.0" | License of the document |
+| externalDocumentRefs | {documentRefId: string, documentUri: string, checksum_value: string, checksum_algorithm: string} | - | External documents referenced by the document |
+| creatorComment | string | - | Comment on the creator |
+| licenseListVersion | string | - | Version of the license list used |
+| documentComment | string | - | Comment on the document |
+
+### Packages
+Packages are used to describe the contents of a software package.
+After creating a document (see [Documents](#Documents)), packages can be added with the command `document.addPackages`:
+
+```javascript
+const pkg = document.addPackage("my-package", {
+    downloadLocation: "https://download-location.com",
+});
+```
+
+It requires the following arguments:
+
+| Argument | Format | Description |
+| ----------- | ----------- | ----------- |
+| name | String | Name of the package |
+
+In addition, it takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| downloadLocation | string | NOASSERTION | Download location of the package |
+| spdxId | string | SPDX-Ref-<UUID V4> | ID of the package |
+| version | string | - | Version of the package |
+| fileName | string | - | File name of the package |
+| supplier | {name: string, type: "Person" / "Organization" / "Tool", email?: string} / "NOASSERTION" | - | Supplier of the package |
+| originator | {name: string, type: "Person" / "Organization" / "Tool", email?: string} / "NOASSERTION" | - | Originator of the package |
+| filesAnalyzed | boolean | false | Indicates whether the package contents have been analyzed |
+| verificationCode | {value: string, excludedFiles?: string[]} | - | Identification for contents of a package |
+| checksums | {checksumValue: string, checksumAlgorithm: string}[] | - | Checksums of the package |
+| homePage | string | - | Homepage of the package |
+| sourceInfo | string | - | Information about the source of the package |
+| licenseConcluded | string | - | License concluded for the package |
+| licenseInfoFromFiles | string[] | [] | Licenses found in the package |
+| licenseDeclared | string | - | License declared for the package |
+| licenseComment | string | - | Comments about the license |
+| copyrightText | string | - | Copyright |
+| summary | string | - | Summary of the package |
+| description | string | - | Description of the package |
+| comment | string | - | Additional information |
+| externalReferences | {referenceType: string, referenceLocator: string, referenceCategory: string, comment?: string;}[] | [] | External references |
+| attributionTexts | string[] | [] | Attribution texts |
+| primaryPackagePurpose | string ("APPLICATION", "FRAMEWORK", "LIBRARY", "CONTAINER", "OPERATING_SYSTEM", "DEVICE", "FIRMWARE", "SOURCE", "ARCHIVE", "FILE", "INSTALL", "OTHER") | - | Primary purpose of the package |
+| releaseDate | Date | - | Release date of the package |
+| buildDate | Date | - | Build date of the package |
+| validUntilDate | Date | - | Date until which the package is valid |
+
+### Files
+Files are used to provide information about files that are contained in software packages.
+After creating a document (see [Documents](#Documents)), files can be added with the command `document.addFiles`:
+
+```javascript
+document.addFile(
+    "my-file",
+    {
+        checksumValue: "de9f2c7fd25e1b3afad3e85a0bd17d9b100db4b3",
+        checksumAlgorithm: "SHA1",
+    },
+    {
+        fileTypes: ["TEXT"],
+        concludedLicense: "MIT",
+    },
+);
+```
+
+It requires the following arguments:
+
+| Argument | Format | Description |
+| ----------- | ----------- | ----------- |
+| name | String | Name of the file |
+| checksums | {checksumValue: string, checksumAlgorithm: string}[] | Checksums of the file |
+
+
+In addition, it takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| spdxId | string | SPDX-Ref-<UUID V4> | ID of the package |
+| fileTypes | string[] | - | Types of the files (for example TEXT) |
+| licenseConcluded | string | - | License of the file |
+| licenseInfoInFiles | string[] | - | License info found in the file |
+| licenseComment | string | - | Comment on the license |
+| copyrightText | string | - | Copyright holder and other dates of the file | 
+| comment | string | - | Additional information |
+| notice | string | - | Notice of the file |
+| contributors | string[] | - | Contributors of the file |
+| attributionTexts | string[] | - | Acknowledgements about the file |
+
+### Relationships
+Relationships are used to describe the relationship between different SPDX elements.
+After creating a document (see [Documents](#Documents)), relationships can be added with the command `document.createRelationship`:
+
+```javascript
+const relationship = document.createRelationship(
+    "SPDXRef-Document",
+    "SPDXRef-Package",
+    "DESCRIBES",
+);
+```
+
+It requires the following arguments:
+
+| Argument | Format | Description |
+| ----------- | ----------- | ----------- |
+| spdxElement | Document / Package / File / string | spdx element or id that was used to create an spdx element |
+| relatedSpdxElement | Document / Package / File / string | related spdx element or id that was used to create the related spdx element |
+| relationshipType | string | Type of the relationship |
+
+In addition, it takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| comment | string | - | Comment about the relationship |
+
+### Validating a document
+After creating a document (see [Documents](#Documents)), it can be validated with the command `document.validate`:
+Disclaimer: The implementation of the validation is not complete yet.
+
+```javascript
+document.validate();
+```
+
+It takes the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| allowInvalid | boolean | true | Throw an error if the document is invalid |
+
+### Writing a document
+After creating a document (see [Documents](#Documents)), it can be written to a file with the command `document.write` or `document.writeSync`:
+
+```javascript
+document.writeSync("/path/to/my-document.spdx.json");
+```
+
+or asynchronously:
+
+```javascript
+await document.write("/path/to/my-document.spdx.json");
+```
+
+It requires the following arguments:
+
+| Argument | Format | Description |
+| ----------- | ----------- | ----------- |
+| location | string | Path where the file should be written |
+
+In addition, it takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| allowInvalid | boolean | false | Write file even if the SPDX file will be invalid |
+
+

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "0.0.1",
   "description": "A Typescript library for creating SPDX documents",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/spdx/tools-ts.git"
+  },
+  "main": "dist/spdx-tools.cjs",
+  "module": "dist/spdx-tools.mjs",
+  "types": "dist/spdx-tools.d.ts",
   "files": [
     "dist",
-    "README.md",
+    "lib/README.md",
     "CHANGELOG.md",
     "LICENSE",
     "package.json"
@@ -36,6 +43,9 @@
     "tslib": "^2.6.2",
     "typescript": "^5.2.2"
   },
+  "dependencies": {
+    "uuid": "^9.0.1"
+  },
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin typescript",
     "build-examples": "rollup --config examples/rollup.config.ts --configPlugin typescript",
@@ -64,8 +74,5 @@
       "require": "./dist/spdx-tools.cjs",
       "import": "./dist/spdx-tools.mjs"
     }
-  },
-  "dependencies": {
-    "uuid": "^9.0.1"
   }
 }


### PR DESCRIPTION
We add a separate readme for the following reasons:
- The links in the original repository are supposed to work in the web, as well as for local clones. In order to provide those links for the npm registry, we would need to make them absolute and thus not provide local links for clones.
- The contribution and license section do not seem necessary, since the license and repository are defined in the package.json file and shown on the npm registry side panel.
- In the npm registry it makes sense to show more elaborate usage instructions, whereas those should be separated into a documentation file for the Github repository.

Fixes https://github.com/spdx/tools-ts/issues/172