### PR TITLE
Fix lint-staged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: MIT
 
- node_modules
- /dist/
+node_modules/
+/dist/


### PR DESCRIPTION
The pre-commit hooks were failing because of incorrect empty spaces in the .gitignore file

Fixes https://github.com/spdx/tools-ts/issues/190