### PR TITLE
Fix exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Usage instructions in README.md.
+
+## [0.0.6] - 2023-11-30
+### Fixed
+- Export relationshipType correctly. It is an enum and should not be exported as type.

--- a/lib/spdx-tools.ts
+++ b/lib/spdx-tools.ts
@@ -49,11 +49,8 @@ export type {
   PackageOptions,
   PackageVerificationCode,
 } from "./spdx2model/package";
-export { Relationship } from "./spdx2model/relationship";
-export type {
-  RelationshipOptions,
-  RelationshipType,
-} from "./spdx2model/relationship";
+export { Relationship, RelationshipType } from "./spdx2model/relationship";
+export type { RelationshipOptions } from "./spdx2model/relationship";
 export {
   NOASSERTION,
   NONE,


### PR DESCRIPTION
- Fix export of relationshipType
- Add fix to changelog

Before this fix, the library exported relationshipType as a type, but it is an enum and should therefore not be exported as type.

Fixes https://github.com/spdx/tools-ts/issues/197