### PR TITLE
Support other licensing info

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -112,7 +112,6 @@ It requires the following arguments:
 | name | String | Name of the file |
 | checksums | {checksumValue: string, checksumAlgorithm: string}[] | Checksums of the file |
 
-
 In addition, it takes an object with the following optional parameters:
 
 | Argument | Format | Default | Description |
@@ -153,6 +152,36 @@ In addition, it takes an object with the following optional parameters:
 | Argument | Format | Default | Description |
 | ----------- | ----------- | ----------- | ----------- |
 | comment | string | - | Comment about the relationship |
+
+Multiple relationships can be added to a document in a single command:
+
+```javascript
+const relationship = document
+  .createRelationship("SPDXRef-Package", "SPDXRef-File-1", "CONTAINS")
+  .createRelationship("SPDXRef-Package", "SPDXRef-File-2", "CONTAINS");
+```
+
+## Other Licensing Information
+Other licensing information is used to provide a locally unique identifier for a licenses that are not in the SPDX License List.
+After creating a document (see [Documents](#Documents)), other licensing information can be added with the command `document.addOtherLicensingInfo`:
+
+```javascript
+document.addOtherLicensingInformation(
+    {
+      licenseId: "LicenseRef-my-license",
+    },
+);
+```
+
+It requires no arguments, but takes an object with the following optional parameters:
+
+| Argument | Format | Default | Description |
+| ----------- | ----------- | ----------- | ----------- |
+| licenseId | string | - | ID of the license |
+| extractedText | string | - | Text of the license |
+| licenseName | string | - | Name of the license |
+| crossReferences | string[] | - | Pointer to official source of license |
+| comment | string | - | Comment about the license |
 
 ## Validating a document
 After creating a document (see [Documents](#Documents)), it can be validated with the command `document.validate`:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ The following features are supported by this library:
 | Packages | DONE
 | Files | DONE
 | Relationships | DONE
+| Other licensing information | DONE
 | Snippets | PLANNED
 | Annotations | PLANNED
-| Other licensing information | PLANNED
 
 ## API
 We provide a number of example workflows in the `examples` directory that demonstrate how this library can be used to create SBOMs.

--- a/examples/create-elaborate-sample-sbom.ts
+++ b/examples/create-elaborate-sample-sbom.ts
@@ -96,4 +96,13 @@ const firstFile = document.addFile(
 );
 
 document.addRelationship(firstPackage, firstFile, "CONTAINS");
+
+document.addOtherLicensingInformation({
+  licenseId: "LicenseRef-test-license-id",
+  extractedText: "This is an extracted text",
+  licenseName: "Test license name",
+  crossReferences: ["https://test-cross-reference.com"],
+  comment: "This is a comment",
+});
+
 document.writeSync("./examples/resources/elaborate-sample.spdx.json");

--- a/lib/api/spdx-document.ts
+++ b/lib/api/spdx-document.ts
@@ -9,6 +9,7 @@ import { Package } from "../spdx2model/package";
 import { Document } from "../spdx2model/document";
 import { DocumentCreationInfo } from "../spdx2model/document-creation-info";
 import { File } from "../spdx2model/file";
+import { OtherLicensingInfo } from "../spdx2model/other-licensing-info";
 
 export interface SpdxActor {
   name: string;
@@ -88,6 +89,14 @@ export interface AddFileOptions {
   attributionTexts: string[];
 }
 
+export interface AddOtherLicensingInfoOptions {
+  licenseId: string;
+  extractedText: string;
+  licenseName: string;
+  crossReferences: string[];
+  comment: string;
+}
+
 export class SPDXDocument extends Document {
   static createDocument(
     name: string,
@@ -126,6 +135,14 @@ export class SPDXDocument extends Document {
       options,
     );
     this.relationships.push(relationship);
+    return this;
+  }
+
+  addOtherLicensingInformation(
+    options?: Partial<AddOtherLicensingInfoOptions>,
+  ): this {
+    const otherLicensingInfo = OtherLicensingInfo.fromApi(options);
+    this.otherLicensingInfo.push(otherLicensingInfo);
     return this;
   }
 

--- a/lib/converters/json/document.ts
+++ b/lib/converters/json/document.ts
@@ -8,6 +8,7 @@ import { JsonPackage } from "./package";
 import { JsonRelationship } from "./relationship";
 import { JsonExternalDocumentRef } from "./external-document-ref";
 import { JsonFile } from "./file";
+import { JsonHasExtractedLicensingInfos } from "./has-extracted-licensing-infos";
 
 export class JsonDocument {
   SPDXID: string;
@@ -21,6 +22,7 @@ export class JsonDocument {
   packages?: JsonPackage[];
   files?: JsonFile[];
   relationships?: JsonRelationship[];
+  hasExtractedLicensingInfos?: JsonHasExtractedLicensingInfos[];
 
   constructor(
     spdxId: string,
@@ -32,6 +34,7 @@ export class JsonDocument {
     packages?: JsonPackage[],
     files?: JsonFile[],
     relationships?: JsonRelationship[],
+    hasExtractedLicensingInfos?: JsonHasExtractedLicensingInfos[],
     externalDocumentRefs?: JsonExternalDocumentRef[],
     comment?: string,
   ) {
@@ -44,6 +47,7 @@ export class JsonDocument {
     this.packages = packages;
     this.files = files;
     this.relationships = relationships;
+    this.hasExtractedLicensingInfos = hasExtractedLicensingInfos;
     this.externalDocumentRefs = externalDocumentRefs;
     this.comment = comment;
   }
@@ -65,6 +69,16 @@ export class JsonDocument {
             JsonRelationship.fromRelationship(relationship),
           )
         : undefined;
+    const jsonHasExtractedLicensingInfos:
+      | JsonHasExtractedLicensingInfos[]
+      | undefined =
+      document.otherLicensingInfo.length > 0
+        ? document.otherLicensingInfo.map((otherLicenseInfo) =>
+            JsonHasExtractedLicensingInfos.fromOtherLicensingInfo(
+              otherLicenseInfo,
+            ),
+          )
+        : undefined;
     const jsonExternalDocumentRefs: JsonExternalDocumentRef[] | undefined =
       document.creationInfo.externalDocumentRefs?.length > 0
         ? document.creationInfo.externalDocumentRefs.map((ref) =>
@@ -82,6 +96,7 @@ export class JsonDocument {
       jsonPackages,
       jsonFiles,
       jsonRelationships,
+      jsonHasExtractedLicensingInfos,
       jsonExternalDocumentRefs,
       document.creationInfo.documentComment,
     );

--- a/lib/converters/json/has-extracted-licensing-infos.ts
+++ b/lib/converters/json/has-extracted-licensing-infos.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 SPDX contributors
+//
+// SPDX-License-Identifier: MIT
+
+import type { OtherLicensingInfo } from "../../spdx2model/other-licensing-info";
+import { v4 as uuidv4 } from "uuid";
+
+export class JsonHasExtractedLicensingInfos {
+  extractedText: string;
+  licenseId: string;
+  comment?: string;
+  name?: string;
+  seeAlsos?: string[];
+
+  constructor(
+    extractedText: string,
+    licenseId: string,
+    comment?: string,
+    name?: string,
+    seeAlsos?: string[],
+  ) {
+    this.extractedText = extractedText;
+    this.licenseId = licenseId;
+    this.comment = comment;
+    this.name = name;
+    this.seeAlsos = seeAlsos;
+  }
+
+  static fromOtherLicensingInfo(
+    otherLicensingInfo: OtherLicensingInfo,
+  ): JsonHasExtractedLicensingInfos {
+    return new JsonHasExtractedLicensingInfos(
+      otherLicensingInfo.extractedText ?? "",
+      otherLicensingInfo.licenseId ?? "SPDXRef-" + uuidv4(),
+      otherLicensingInfo.comment,
+      otherLicensingInfo.licenseName?.toString(),
+      otherLicensingInfo.crossReferences,
+    );
+  }
+}

--- a/lib/e2e-tests/__tests__/spdx-tools.test.ts
+++ b/lib/e2e-tests/__tests__/spdx-tools.test.ts
@@ -9,6 +9,7 @@ import type { JsonPackage } from "../../converters/json/package";
 import type { JsonFile } from "../../converters/json/file";
 import { Validator } from "jsonschema";
 import * as spdxSchema from "./resources/spdx-schema.json";
+import type { JsonHasExtractedLicensingInfos } from "../../converters/json/has-extracted-licensing-infos";
 
 afterEach(() => {
   mock.restore();
@@ -303,6 +304,14 @@ test("Creates and writes elaborate document", async () => {
 
   document.addRelationship(firstPackage, firstFile, "CONTAINS");
 
+  document.addOtherLicensingInformation({
+    licenseId: "LicenseRef-test-license-id",
+    extractedText: "This is an extracted text",
+    licenseName: "Test license name",
+    crossReferences: ["https://test-cross-reference.com"],
+    comment: "This is a comment",
+  });
+
   await document.write(testfile).then(() => {
     expect(fs.lstatSync(testfile).isFile()).toBe(true);
     const writtenFileContent = fs.readFileSync(testfile, { encoding: "utf-8" });
@@ -333,6 +342,14 @@ test("Creates and writes elaborate document", async () => {
     );
     expect(fileNames.length).toBe(1);
     expect(fileNames).toContain("first file");
+
+    const extractedLicensingInfos =
+      parsedFileContent.hasExtractedLicensingInfos.map(
+        (licensingInfo: JsonHasExtractedLicensingInfos) =>
+          licensingInfo.licenseId,
+      );
+    expect(extractedLicensingInfos.length).toBe(1);
+    expect(extractedLicensingInfos).toContain("LicenseRef-test-license-id");
 
     const relationships = parsedFileContent.relationships;
     expect(relationships).toContainEqual({

--- a/lib/spdx2model/__tests__/other-licensing-info.test.ts
+++ b/lib/spdx2model/__tests__/other-licensing-info.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 SPDX contributors
+//
+// SPDX-License-Identifier: MIT
+
+import { OtherLicensingInfo } from "../other-licensing-info";
+import { SpdxNoAssertion } from "../utils";
+
+describe("OtherLicensingInfo", () => {
+  it("Creates correct describes other license info from api with options", () => {
+    const licenseId = "LicenseRef-test-id";
+    const extractedText = "This is the license text";
+    const crossReferences = ["https://example.com"];
+    const comment = "This is a comment";
+
+    expect(
+      OtherLicensingInfo.fromApi({
+        licenseId,
+        extractedText,
+        licenseName: "NOASSERTION",
+        crossReferences,
+        comment,
+      }),
+    ).toStrictEqual(
+      new OtherLicensingInfo({
+        licenseId,
+        extractedText,
+        licenseName: new SpdxNoAssertion(),
+        crossReferences,
+        comment,
+      }),
+    );
+  });
+});

--- a/lib/spdx2model/document.ts
+++ b/lib/spdx2model/document.ts
@@ -8,11 +8,13 @@ import type { DocumentCreationInfo } from "./document-creation-info";
 import { JsonDocument } from "../converters/json/document";
 import fs from "fs/promises";
 import type { File } from "./file";
+import type { OtherLicensingInfo } from "./other-licensing-info";
 
 export interface DocumentOptions {
   packages: Package[];
   files: File[];
   relationships: Relationship[];
+  otherLicensingInfo: OtherLicensingInfo[];
 }
 
 export function itemsHaveDuplicateId(
@@ -33,6 +35,7 @@ export class Document {
   packages: Package[];
   files: File[];
   relationships: Relationship[];
+  otherLicensingInfo: OtherLicensingInfo[];
 
   constructor(
     creationInfo: DocumentCreationInfo,
@@ -42,6 +45,7 @@ export class Document {
     this.packages = options?.packages ?? [];
     this.files = options?.files ?? [];
     this.relationships = options?.relationships ?? [];
+    this.otherLicensingInfo = options?.otherLicensingInfo ?? [];
   }
 
   private hasMissingDescribesRelationships(): boolean {

--- a/lib/spdx2model/file.ts
+++ b/lib/spdx2model/file.ts
@@ -82,7 +82,7 @@ export class File {
     options?: Partial<AddFileOptions>,
   ): File {
     return new File(name, Checksum.fromSpdxChecksums(checksums), {
-      spdxId: options?.spdxId ?? undefined,
+      spdxId: options?.spdxId,
       fileTypes: options?.fileTypes
         ? options.fileTypes.map((fileType) => formatFileType(fileType))
         : undefined,
@@ -91,13 +91,13 @@ export class File {
       licenseInfoInFiles: options?.licenseInfoInFiles?.map((licenseInfo) =>
         toSpdxType(licenseInfo),
       ),
-      licenseComment: options?.licenseComment ?? undefined,
+      licenseComment: options?.licenseComment,
       copyrightText:
         options?.copyrightText && toSpdxType(options.copyrightText),
-      comment: options?.comment ?? undefined,
-      notice: options?.notice ?? undefined,
-      contributors: options?.contributors ?? [],
-      attributionTexts: options?.attributionTexts ?? [],
+      comment: options?.comment,
+      notice: options?.notice,
+      contributors: options?.contributors,
+      attributionTexts: options?.attributionTexts,
     });
   }
 }

--- a/lib/spdx2model/other-licensing-info.ts
+++ b/lib/spdx2model/other-licensing-info.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2023 SPDX contributors
+//
+// SPDX-License-Identifier: MIT
+
+import type { SpdxNoAssertion } from "./utils";
+import { toSpdxType } from "./utils";
+import type { AddOtherLicensingInfoOptions } from "../api/spdx-document";
+
+export interface OtherLicensingInfoOptions {
+  licenseId: string;
+  extractedText: string;
+  licenseName: string | SpdxNoAssertion;
+  crossReferences: string[];
+  comment: string;
+}
+
+export class OtherLicensingInfo {
+  licenseId?: string;
+  extractedText?: string;
+  licenseName?: string | SpdxNoAssertion;
+  crossReferences: string[];
+  comment?: string;
+
+  constructor(options?: Partial<OtherLicensingInfoOptions>) {
+    this.licenseId = options?.licenseId ?? undefined;
+    this.extractedText = options?.extractedText ?? undefined;
+    this.licenseName = options?.licenseName ?? undefined;
+    this.crossReferences = options?.crossReferences ?? [];
+    this.comment = options?.comment ?? undefined;
+  }
+
+  static fromApi(
+    options?: Partial<AddOtherLicensingInfoOptions>,
+  ): OtherLicensingInfo {
+    return new OtherLicensingInfo({
+      licenseId: options?.licenseId,
+      extractedText: options?.extractedText,
+      licenseName: options?.licenseName && toSpdxType(options.licenseName),
+      crossReferences: options?.crossReferences,
+      comment: options?.comment,
+    });
+  }
+}


### PR DESCRIPTION
- Add other licensing info to the model
- Add has extracted licensing info to the json converter
- Add other licensing info to API
- Add other licensing info to elaborate sample sbom
- Add other licensing info to e2e test
- Add unit test for other licensing info
- Add other licensing info to documentation

fixes https://github.com/spdx/tools-ts/issues/210